### PR TITLE
[PR for issue #92] Update ruby versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 cache: bundler
 rvm:
   - 2.4.9
-  - 2.5.7
-  - 2.6.5
-before_install: gem install bundler -v 2.0.2
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
+before_install: gem install bundler -v 2.1.4
 notifications:
   email:
     on_success: never # default: change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Issues marked as **(Internal)** mark internal development work. Issues are track
 ## Next Release
 
 1. [#90](../../issues/90) Use `pry-byebug ~> 3.9.0`. **(Internal)**
+1. [#92](../../issues/92) Update ruby versions in `.travis.yml`. **(Internal)**
 
 ## 1.7.2 (Dec 20, 2019)
 


### PR DESCRIPTION
Closes #92

Ruby 2.4.10 isn't available on travis yet.